### PR TITLE
Catching cron exception.

### DIFF
--- a/src/ProcessManagerBundle/EventListener/CronListener.php
+++ b/src/ProcessManagerBundle/EventListener/CronListener.php
@@ -38,7 +38,11 @@ class CronListener
     {
         /** @var Executable $executable */
         foreach ($this->getExecutables() as $executable) {
-            $cron = CronExpression::factory($executable->getCron());
+            try {
+                $cron = CronExpression::factory($executable->getCron());
+            } catch (\Exception $exception) {
+                continue;
+            }
             $lastrun =  new \DateTime();
             $lastrun->setTimestamp($executable->getLastrun());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Incorrect cron expressions in executables caused pimcore:maintenance to error out. This PR fixes this.