### PR TITLE
Feature/remove modal from executable

### DIFF
--- a/src/ProcessManagerBundle/Resources/public/pimcore/js/executable/item.js
+++ b/src/ProcessManagerBundle/Resources/public/pimcore/js/executable/item.js
@@ -43,7 +43,7 @@ pimcore.plugin.processmanager.executable.item = Class.create({
             width: 800,
             height: 400,
             resizeable: true,
-            modal: true,
+            modal: false,
             layout: 'fit',
             title: t('processmanager_executables'),
             iconCls: 'processmanager_icon_executable',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | maybe
| New feature?  | kind of ;)
| BC breaks?    | no
| Deprecations? | no

A new executable window is modal, which prevents dragging and dropping Pimcore elements into its configuration. This PR sets modal of this window to false.
