### PR TITLE
Fix Logger returning invalid value

### DIFF
--- a/src/ProcessManagerBundle/Monolog/ProcessHandler.php
+++ b/src/ProcessManagerBundle/Monolog/ProcessHandler.php
@@ -42,7 +42,7 @@ class ProcessHandler extends AbstractHandler
     public function handle(array $record)
     {
         if (!array_key_exists('process', $record['extra'])) {
-            return true;
+            return false;
         }
 
         return $this->logProcessIntoRegularLogFile;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Logger handler must return true only if a log was stored. If a record contains no 'process' in extra, it is not saved, thus returned value must be false.
https://github.com/Seldaek/monolog/blob/ebb804e432e8fe0fe96828f30d89c45581d36d07/src/Monolog/Handler/HandlerInterface.php#L47