### PR TITLE
Allow logger to handle compressed log files

### DIFF
--- a/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
+++ b/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
@@ -37,7 +37,12 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
      */
     public function getLogHandler(ProcessInterface $process)
     {
-        return new StreamHandler(sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId()));
+        // if no archive, load regular file
+        if (false === ($path = $this->getArchiveFileStreamWrapper($process))) {
+            $path = $this->getLogFilePath($process);
+        }
+
+        return new StreamHandler($path);
     }
 
     /**
@@ -45,10 +50,15 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
      */
     public function getLog(ProcessInterface $process)
     {
-        $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
-
-        if (file_exists($path)) {
+        // if archive, load content
+        if (false !== ($path = $this->getArchiveFileStreamWrapper($process))) {
             return file_get_contents($path);
+        } else { // regular file
+            $path = $this->getLogFilePath($process);
+
+            if (file_exists($path)) {
+                return file_get_contents($path);
+            }
         }
 
         return '';
@@ -59,10 +69,63 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
      */
     public function cleanup(ProcessInterface $process)
     {
-        $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
+        $archivePath = $this->getArchiveFilePath($process);
+
+        if (file_exists($archivePath)) {
+            unlink($archivePath);
+        }
+
+        $path = $this->getLogFilePath($process);
 
         if (file_exists($path)) {
             unlink($path);
         }
+    }
+
+    /**
+     * Get log filename full path
+     * @param ProcessInterface $process
+     * @return string
+     */
+    private function getLogFilePath(ProcessInterface $process)
+    {
+        return sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
+    }
+
+    /**
+     * Find log file in log directory and return file name if it is found.
+     * Archived file name example is process_manager_480-archive-2019-04-16.log.gz which contains file
+     * process_manager_480-archive-2019-04-16.log
+     * @param ProcessInterface $process
+     * @return string|boolean first log file name matching criteria or false if not found
+     */
+    private function getArchiveFilePath(ProcessInterface $process)
+    {
+        $archivePattern = sprintf(
+            '%s/process_manager_%s-archive-*.log.gz',
+            $this->logDirectory,
+            $process->getId()
+        );
+
+        // load file list
+        $archivedLogFiles = glob($archivePattern);
+
+        return reset($archivedLogFiles);
+    }
+
+    /**
+     * Return stream wrapper path to be used to open file.
+     * @param ProcessInterface $process
+     * @return bool|string
+     */
+    private function getArchiveFileStreamWrapper(ProcessInterface $process)
+    {
+        // archive file does not exist
+        if(false === ($archivePath = $this->getArchiveFilePath($process))) {
+            return false;
+        }
+
+        // there is only one file in archive, no need to specify its filename
+        return sprintf('compress.zlib://%s', $archivePath);
     }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix?      | yes
| New feature? | no
| BC Break? | no
| Deprecations?             | no

Related to issue #32.

Method `Pimcore\Log\Maintenance::cleanupLogFiles()` which seems to be run during Pimcore maintenance is compressing the log files into GZ and keeping them for 7 days. So as your library is storing the logs into `PIMCORE_LOG_DIRECTORY` those are affected as well. 

Code of `ProcessManagerBundle\Logger\DefaultHandlerFactory` is expecting for `getLog` method the file name is `process_manager_%s.log` however the name is `process_manager_%s.log.gz`. That is the reason that method will fail to load compressed log files and this lead to not working functionality to show or download log for log entries which were compressed. This is affecting than the controller method `ProcessManagerBundle\Controller\ProcessController::getLog` which is unable to return the log data.
