### PR TITLE
Change CronListener to a maintenance task to support Pimcore 6

### DIFF
--- a/src/ProcessManagerBundle/Maintenance/CronTask.php
+++ b/src/ProcessManagerBundle/Maintenance/CronTask.php
@@ -12,13 +12,14 @@
  * @license    https://github.com/dpfaffenbauer/ProcessManager/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
  */
 
-namespace ProcessManagerBundle\EventListener;
+namespace ProcessManagerBundle\Maintenance;
 
+use Pimcore\Maintenance\TaskInterface;
 use CoreShop\Component\Registry\ServiceRegistry;
 use Cron\CronExpression;
 use ProcessManagerBundle\Model\Executable;
 
-class CronListener
+class CronTask implements TaskInterface
 {
     private $registry;
 
@@ -34,7 +35,7 @@ class CronListener
     /**
      * Runs waiting crons
      */
-    public function run()
+    public function execute()
     {
         /** @var Executable $executable */
         foreach ($this->getExecutables() as $executable) {

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -47,10 +47,11 @@ services:
         tags:
             - { name: kernel.event_listener, event: pimcore.asset.postDelete, method: onArtifactAssetDelete }
 
-    process_manager.event_listener.cron:
-        class: ProcessManagerBundle\EventListener\CronListener
+    ### Maintenance task
+    process_manager.maintenance.cron:
+        class: ProcessManagerBundle\Maintenance\CronTask
         tags:
-            - { name: kernel.event_listener, event: pimcore.system.maintenance, method: run, arguments: }
+            - { name: pimcore.maintenance.task, type: process_manager.maintenance.cron }
         arguments:
             - '@process_manager.registry.processes'
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #35 -->

CronListener uses the event pimcore.system.maintenance which is removed in Pimcore 6. Change CronListener to a maintenance task instead. 
