### PR TITLE
Config to prevent log file cleanup

### DIFF
--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -44,6 +44,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
+                ->booleanNode('prevent_logfile_cleanup')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
-                ->booleanNode('prevent_logfile_cleanup')->defaultFalse()->end()
+                ->scalarNode('log_directory')->defaultValue('%kernel.logs_dir%')->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
+++ b/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
@@ -32,6 +32,8 @@ class ProcessManagerExtension extends AbstractModelExtension
         $this->registerResources('process_manager', $config['driver'], $config['resources'], $container);
         $this->registerPimcoreResources('process_manager', $config['pimcore_admin'], $container);
 
+        $container->setParameter('process_manager.prevent_logfile_cleanup', $config['prevent_logfile_cleanup']);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
+++ b/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
@@ -32,7 +32,7 @@ class ProcessManagerExtension extends AbstractModelExtension
         $this->registerResources('process_manager', $config['driver'], $config['resources'], $container);
         $this->registerPimcoreResources('process_manager', $config['pimcore_admin'], $container);
 
-        $container->setParameter('process_manager.prevent_logfile_cleanup', $config['prevent_logfile_cleanup']);
+        $container->setParameter('process_manager.log_directory', $config['log_directory']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
+++ b/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
@@ -25,18 +25,11 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     private $logDirectory;
 
     /**
-     * @var bool
-     */
-    private $preventLogfileCleanup;
-
-    /**
      * @param string $logDirectory
-     * @param bool   $preventLogfileCleanup
      */
-    public function __construct(string $logDirectory, bool $preventLogfileCleanup)
+    public function __construct(string $logDirectory)
     {
         $this->logDirectory = $logDirectory;
-        $this->preventLogfileCleanup = $preventLogfileCleanup;
     }
 
     /**
@@ -44,14 +37,6 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
      */
     public function getLogHandler(ProcessInterface $process)
     {
-        if ($this->preventLogfileCleanup) {
-            return new StreamHandler(sprintf(
-                '%s/processmanager/process_manager_%s.log',
-                $this->logDirectory,
-                $process->getId()
-            ));
-        }
-
         return new StreamHandler(sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId()));
     }
 
@@ -61,10 +46,6 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     public function getLog(ProcessInterface $process)
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
-
-        if ($this->preventLogfileCleanup) {
-            $path = sprintf('%s/processmanager/process_manager_%s.log', $this->logDirectory, $process->getId());
-        }
 
         if (file_exists($path)) {
             return file_get_contents($path);
@@ -79,10 +60,6 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     public function cleanup(ProcessInterface $process)
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
-
-        if ($this->preventLogfileCleanup) {
-            $path = sprintf('%s/processmanager/process_manager_%s.log', $this->logDirectory, $process->getId());
-        }
 
         if (file_exists($path)) {
             unlink($path);

--- a/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
+++ b/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
@@ -25,11 +25,18 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     private $logDirectory;
 
     /**
-     * @param string $logDirectory
+     * @var bool
      */
-    public function __construct(string $logDirectory)
+    private $preventLogfileCleanup;
+
+    /**
+     * @param string $logDirectory
+     * @param bool   $preventLogfileCleanup
+     */
+    public function __construct(string $logDirectory, bool $preventLogfileCleanup)
     {
         $this->logDirectory = $logDirectory;
+        $this->preventLogfileCleanup = $preventLogfileCleanup;
     }
 
     /**
@@ -37,6 +44,14 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
      */
     public function getLogHandler(ProcessInterface $process)
     {
+        if ($this->preventLogfileCleanup) {
+            return new StreamHandler(sprintf(
+                '%s/processmanager/process_manager_%s.log',
+                $this->logDirectory,
+                $process->getId()
+            ));
+        }
+
         return new StreamHandler(sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId()));
     }
 
@@ -46,6 +61,10 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     public function getLog(ProcessInterface $process)
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
+
+        if ($this->preventLogfileCleanup) {
+            $path = sprintf('%s/processmanager/process_manager_%s.log', $this->logDirectory, $process->getId());
+        }
 
         if (file_exists($path)) {
             return file_get_contents($path);
@@ -60,6 +79,10 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     public function cleanup(ProcessInterface $process)
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
+
+        if ($this->preventLogfileCleanup) {
+            $path = sprintf('%s/processmanager/process_manager_%s.log', $this->logDirectory, $process->getId());
+        }
 
         if (file_exists($path)) {
             unlink($path);

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -75,8 +75,7 @@ services:
     process_manager.default_handler_factory:
         class: ProcessManagerBundle\Logger\DefaultHandlerFactory
         arguments:
-            - '%kernel.logs_dir%'
-            - '%process_manager.prevent_logfile_cleanup%'
+            - '%process_manager.log_directory%'
 
     process_manager.default_report:
         class: ProcessManagerBundle\Report\DefaultReport

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -76,6 +76,7 @@ services:
         class: ProcessManagerBundle\Logger\DefaultHandlerFactory
         arguments:
             - '%kernel.logs_dir%'
+            - '%process_manager.prevent_logfile_cleanup%'
 
     process_manager.default_report:
         class: ProcessManagerBundle\Report\DefaultReport


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixes Issue | https://github.com/dpfaffenbauer/ProcessManager/issues/32

This PR introduces a new configuration `prevent_logfile_cleanup`. If it is set to true, all log files generated by ProcessManager are stored in `/var/logs/processmanager` instead of `/var/logs`. 

Why you may ask? Well, Pimcore maintenance gzips all log files in `/var/logs` from time to time and so the logs of the ProcessManager, which are used as statistical reports, are not found anymore.