### PR TITLE
build: update "dragonmantank/cron-expression"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "coreshop/resource-bundle": "^3.0",
     "pimcore/pimcore": "^6.6",
-    "dragonmantank/cron-expression": "^2.0"
+    "dragonmantank/cron-expression": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR updates the dependency "dragonmantank/cron-expression" to use version 3 and above. Otherwise you're not able to use ProcessManager with for example the Pimcore CMF (see https://github.com/pimcore/customer-data-framework/blob/master/composer.json#L12).
