### PR TITLE
Fix typo in `process_manager_executables.lastrun` field type

### DIFF
--- a/src/ProcessManagerBundle/Installer.php
+++ b/src/ProcessManagerBundle/Installer.php
@@ -48,7 +48,7 @@ class Installer extends SettingsStoreAwareInstaller
         $execTable->addColumn('cron', 'string');
         $execTable->addColumn('settings', 'text');
         $execTable->addColumn('active', 'boolean')->setDefault(1);
-        $execTable->addColumn('lastrun', 'bitint')->setDefault(0)->setNotnull(false);
+        $execTable->addColumn('lastrun', 'bigint')->setDefault(0)->setNotnull(false);
         $execTable->setPrimaryKey(['id']);
 
         $permission = new Permission\Definition();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #63 

Fix typo in field type.
