### PR TITLE
Fix empty cron in Executable list

### DIFF
--- a/src/ProcessManagerBundle/Resources/config/serializer/Model.Executable.yml
+++ b/src/ProcessManagerBundle/Resources/config/serializer/Model.Executable.yml
@@ -34,4 +34,4 @@ ProcessManagerBundle\Model\Executable:
     cron:
       expose: true
       type: string
-      groups: [Detailed]
+      groups: [List, Detailed]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Added missing `cron` field to serializer group `List` causing empty field in Executable list
