### PR TITLE
read processes list directly from the container

### DIFF
--- a/src/ProcessManagerBundle/Controller/ExecutableController.php
+++ b/src/ProcessManagerBundle/Controller/ExecutableController.php
@@ -83,6 +83,6 @@ class ExecutableController extends ResourceController
 
     protected function getConfigTypes(): array
     {
-        return $this->getParameter('process_manager.processes');
+        return $this->container->getParameter('process_manager.processes');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Resolves an issue in Pimcore X (10.2.8) which fails to load the Admin UI for ProcessManager. The error looks like this
```
The "ProcessManagerBundle\Controller\ExecutableController::getParameter()" method is missing
a parameter bag to work properly. Did you forget to register your controller as a service
subscriber? This can be fixed either by using autoconfiguration or by manually wiring a
"parameter_bag" in the service locator passed to the controller.
```
The actual method called is the Symfony's `AbstractController::getParameter()` which uses an optionally specified `parameter_bag` for the service locator, and this is not passed on here.

This change does not use the Symfony's method, instead we read the needed parameter directly from the container.