### PR TITLE
$command in Console::runPhpScriptInBackground has to be an array

### DIFF
--- a/src/ProcessManagerBundle/Process/Pimcore.php
+++ b/src/ProcessManagerBundle/Process/Pimcore.php
@@ -22,7 +22,7 @@ class Pimcore implements ProcessInterface
     function run(ExecutableInterface $executable, array $params = []): int
     {
         $settings = $executable->getSettings();
-        $command = $settings['command'];
+        $command = [$settings['command']];
 
         return Console::runPhpScriptInBackground(PIMCORE_PROJECT_ROOT . "/bin/console", $command);
     }


### PR DESCRIPTION
see: https://github.com/pimcore/pimcore/blob/10.x/lib/Tool/Console.php#L238

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

$command in Console::runPhpScriptInBackground has to be an array
