### PR TITLE
fix: allow null to be passed as params to be in line with data definitions

### DIFF
--- a/src/ProcessManagerBundle/Process/Cli.php
+++ b/src/ProcessManagerBundle/Process/Cli.php
@@ -19,7 +19,7 @@ use ProcessManagerBundle\Model\ExecutableInterface;
 
 final class Cli implements ProcessInterface
 {
-    function run(ExecutableInterface $executable, array $params = []): int
+    function run(ExecutableInterface $executable, ?array $params = []): int
     {
         $settings = $executable->getSettings();
         $command = $settings['command'];

--- a/src/ProcessManagerBundle/Process/Pimcore.php
+++ b/src/ProcessManagerBundle/Process/Pimcore.php
@@ -19,7 +19,7 @@ use ProcessManagerBundle\Model\ExecutableInterface;
 
 class Pimcore implements ProcessInterface
 {
-    function run(ExecutableInterface $executable, array $params = []): int
+    function run(ExecutableInterface $executable, ?array $params = []): int
     {
         $settings = $executable->getSettings();
         $command = $settings['command'];

--- a/src/ProcessManagerBundle/Process/ProcessInterface.php
+++ b/src/ProcessManagerBundle/Process/ProcessInterface.php
@@ -18,5 +18,5 @@ use ProcessManagerBundle\Model\ExecutableInterface;
 
 interface ProcessInterface
 {
-    function run(ExecutableInterface $executable, array $params = []): int;
+    function run(ExecutableInterface $executable, ?array $params = []): int;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
when running crons, they fail because data definitions would give `null` value as `$params`. since `$params` aren't even used, i don't see why wouldn't we accept `null` as a value.

ps. why not remove params if they're not actually used (from both projects)?
