### PR TITLE
fix: don't wrap command in an array, cast to array if string

### DIFF
--- a/src/ProcessManagerBundle/Process/Pimcore.php
+++ b/src/ProcessManagerBundle/Process/Pimcore.php
@@ -22,8 +22,8 @@ class Pimcore implements ProcessInterface
     public function run(ExecutableInterface $executable, array $params = []): int
     {
         $settings = $executable->getSettings();
-        $command = $settings['command'];
+        $command = (array) $settings['command'];
 
-        return Console::runPhpScriptInBackground(PIMCORE_PROJECT_ROOT . "/bin/console", [$command]);
+        return Console::runPhpScriptInBackground(PIMCORE_PROJECT_ROOT . "/bin/console", $command);
     }
 }


### PR DESCRIPTION
From DataDefs it's already an array, leading to double wrapping

Basically, it will cast to an array if it's a string (CLI and Pimcore), but keep as-is if already an array (data defs).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | chat
