### PR TITLE
fix: don't run jobs in background

### DIFF
--- a/src/ProcessManagerBundle/Process/Pimcore.php
+++ b/src/ProcessManagerBundle/Process/Pimcore.php
@@ -24,6 +24,8 @@ class Pimcore implements ProcessInterface
         $settings = $executable->getSettings();
         $command = (array) $settings['command'];
 
-        return Console::runPhpScriptInBackground(PIMCORE_PROJECT_ROOT . "/bin/console", $command);
+        Console::runPhpScript(PIMCORE_PROJECT_ROOT . "/bin/console", $command);
+
+        return 0;
     }
 }


### PR DESCRIPTION
Since they're now running on workers which need to know they're still running them. Fixes #82.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #82 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
