### PR TITLE
fix: schedule jobs from CronTask instead of running them directly

### DIFF
--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -48,6 +48,7 @@ services:
     ProcessManagerBundle\Maintenance\CronTask:
         arguments:
             - '@process_manager.registry.processes'
+            - '@messenger.default_bus'
         tags:
             - { name: pimcore.maintenance.task, type: process_manager.maintenance.cron }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

If the cronjobs take a while to execute, they might never get marked as "last run", making them run many many times. This fix schedules jobs instead, but marking them as run so they don't get double-run.