### PR TITLE
fix: Do not mark log records as handled if it's not a process manager record

### DIFF
--- a/src/ProcessManagerBundle/Monolog/ProcessHandler.php
+++ b/src/ProcessManagerBundle/Monolog/ProcessHandler.php
@@ -42,7 +42,7 @@ class ProcessHandler extends AbstractHandler
     public function handle(array $record)
     {
         if (!array_key_exists('process', $record['extra'])) {
-            return true;
+            return false;
         }
 
         return $this->logProcessIntoRegularLogFile;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  https://github.com/dpfaffenbauer/ProcessManager/pull/31

Re-roll of https://github.com/dpfaffenbauer/ProcessManager/pull/31 because _this is bad_.
The current setup hijacks the monolog handlers via [ProcessManagerBundle/DependencyInjection/Compiler/MonologHandlerPass](https://github.com/dpfaffenbauer/ProcessManager/blob/2.6/src/ProcessManagerBundle/DependencyInjection/Compiler/MonologHandlerPass.php) and subsequently doesn't properly integrate with the Monolog API in [\ProcessManagerBundle\Monolog\ProcessHandler::handle()](https://github.com/dpfaffenbauer/ProcessManager/blob/f5921e2cf83ccc29a78d1f9f9f1f1ac55e9d4aca/src/ProcessManagerBundle/Monolog/ProcessHandler.php#L45).
Returning `true` in there indicates that the record has been handled and doesn't need any further handling- skipping all other handlers.
Which means this handler drops _all_ log records that aren't related to itself. E.g. essentially suppressing the logging of pimcores maintenance task handling.
