### PR TITLE
fix: correctly auto-reload the processes grid again

### DIFF
--- a/src/ProcessManagerBundle/Resources/public/pimcore/js/processes.js
+++ b/src/ProcessManagerBundle/Resources/public/pimcore/js/processes.js
@@ -26,9 +26,7 @@ pimcore.plugin.processmanager.processes = Class.create({
     },
 
     reloadProcesses: function() {
-        pimcore.globalmanager.get(this.storeId).load(function () {
-            this.createInterval();
-        }.bind(this));
+        pimcore.globalmanager.get(this.storeId).load();
     },
 
     clear: function(seconds, msg) {
@@ -94,6 +92,10 @@ pimcore.plugin.processmanager.processes = Class.create({
                 { name:'artifact' }
             ]
         });
+
+        store.on('load', function () {
+            this.createInterval();
+        }.bind(this));
 
         pimcore.globalmanager.add(this.storeId, store);
         this.reloadProcesses();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

This makes the processes grid auto-reload again, it stopped working in P11.